### PR TITLE
[NIGHTLY] feat: use tokio to provide async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ bitflags    = "1"
 futures     = "0.1"
 inotify-sys = "0.1.1"
 libc        = "0.2"
+tokio-core  = "0.1"
+tokio-io    = "0.1"
+tokio-file-unix = "0.4"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
This improves upon the previous implementation in that it uses Tokio to
handle waiting on the inotify file descriptor rather than always
scheduling itself when it can't read any data.

---
From discussion in #99, it was decided to use a less-than-optimal yet doesn't-require-nightly implementation for now. Here is the "uses nightly" variant. It also relies upon an as-yet unreviewed Tokio change (tokio-rs/tokio#144).