### PR TITLE
refactor: Add FdGuard responsible for close-on-drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,7 +596,7 @@ impl Deref for FdGuard {
 
 impl Drop for FdGuard {
     fn drop(&mut self) {
-        if self.close_on_drop.load(Ordering::Relaxed) {
+        if self.close_on_drop.load(Ordering::Release) {
             unsafe { ffi::close(self.fd); }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,22 +489,6 @@ impl Inotify {
         EventStream::new(self.fd.clone())
     }
 
-    /// Transform `self` into a `Stream` of events.
-    ///
-    /// This behaves the same as [`Inotify::event_stream`]. Since the file
-    /// descriptor management issues that necessitated this function have
-    /// been fixed, it should no longer be necessary, and
-    /// [`Inotify::event_stream`] should be used instead.
-    ///
-    /// [`Inotify::event_stream`]: struct.Inotify.html#method.event_stream
-    #[deprecated(
-        since = "0.5.2",
-        note = "use [`Inotify::event_stream`](struct.Inotify.html#method.event_stream) instead."
-    )]
-    pub fn into_event_stream(self) -> EventStream {
-        EventStream::new(self.fd)
-    }
-
     /// Closes the inotify instance
     ///
     /// Closes the file descriptor referring to the inotify instance. The user

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,7 +581,7 @@ impl FdGuard {
     /// always used consistently.
     #[inline]
     fn should_not_close(&self) {
-        self.close_on_drop.store(false, Ordering::Acquire);
+        self.close_on_drop.store(false, Ordering::Release);
     }
 }
 
@@ -596,7 +596,7 @@ impl Deref for FdGuard {
 
 impl Drop for FdGuard {
     fn drop(&mut self) {
-        if self.close_on_drop.load(Ordering::Release) {
+        if self.close_on_drop.load(Ordering::Acquire) {
             unsafe { ffi::close(self.fd); }
         }
     }


### PR DESCRIPTION
This commit improves the close-on-drop behaviour for file descriptors,
by adding a `FdGuard` struct that wraps the file descriptor and is
responsible for closing it when it is dropped. Rather than having an
`Inotify` own an `Arc<RawFd>`, and be responsible for clsoing it,
`Inotify` now owns an `Arc<FdGuard>`, and the `FdGuard` is responsible
for closing the fd.

This allows us to share the file descriptor between an `Inotify` and
an `EventStream`, and close the file descriptor only when the `Arc` is
dropped (i.e., when both the `Inotify` _and_ the `EventStream` are
dropped). This makes the `Inotify::into_event_stream` I added in #103
unnecessary, so I've gone ahead and deprecated it.