### PR TITLE
feat: Implement `EventStream` using `mio`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,13 @@ maintenance = { status = "actively-developed" }
 travis-ci   = { repository = "inotify-rs/inotify" }
 
 [dependencies]
-bitflags    = "1"
-futures     = "0.1"
-inotify-sys = "0.1.1"
-libc        = "0.2"
+bitflags      = "1"
+futures       = "0.1"
+inotify-sys   = "0.1.1"
+libc          = "0.2"
+mio           = "0.6"
+tokio-io      = "0.1"
+tokio-reactor = "0.1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,18 @@ categories = ["api-bindings", "filesystem"]
 maintenance = { status = "actively-developed" }
 travis-ci   = { repository = "inotify-rs/inotify" }
 
+[features]
+default = ["stream"]
+stream = ["futures", "mio", "tokio-io", "tokio-reactor"]
+
 [dependencies]
 bitflags      = "1"
-futures       = "0.1"
+futures       = { version = "0.1", optional = true }
 inotify-sys   = "0.1.1"
 libc          = "0.2"
-mio           = "0.6"
-tokio-io      = "0.1"
-tokio-reactor = "0.1"
+mio           = { version = "0.6", optional = true }
+tokio-io      = { version = "0.1", optional = true }
+tokio-reactor = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,13 +73,15 @@
 
 #[macro_use]
 extern crate bitflags;
+
+#[cfg(feature = "stream")]
 #[macro_use]
 extern crate futures;
 
 extern crate libc;
 extern crate inotify_sys as ffi;
-extern crate mio;
-extern crate tokio_io;
+
+#[cfg(feature = "stream")]
 extern crate tokio_reactor;
 
 use std::mem;
@@ -113,7 +115,6 @@ use std::ffi::{
     CString,
 };
 
-use futures::{Async, Poll, Stream};
 use libc::{
     FILENAME_MAX,
     F_GETFL,
@@ -124,13 +125,15 @@ use libc::{
     size_t,
     c_int,
 };
-use mio::{
-    event::Evented,
-    unix::EventedFd,
-};
-use tokio_reactor::{Handle, PollEvented};
-use tokio_io::AsyncRead;
 
+#[cfg(feature = "stream")]
+use tokio_reactor::Handle;
+
+#[cfg(feature = "stream")]
+mod stream;
+
+#[cfg(feature = "stream")]
+pub use self::stream::EventStream;
 
 /// Idiomatic Rust wrapper around Linux's inotify API
 ///
@@ -495,6 +498,7 @@ impl Inotify {
     /// An internal buffer which can hold the maximum possible size is used.
     ///
     /// The event stream will be associated with the default reactor.
+    #[cfg(feature = "stream")]
     pub fn event_stream(&mut self) -> EventStream {
         EventStream::new(self.fd.clone())
     }
@@ -507,6 +511,7 @@ impl Inotify {
     /// than the default.
     ///
     /// [`Inotify::event_stream`]: struct.Inotify.html#method.event_stream
+    #[cfg(feature = "stream")]
     pub fn event_stream_with_handle(&mut self, handle: &Handle)
                                     -> io::Result<EventStream>
     {
@@ -647,135 +652,9 @@ impl AsRawFd for FdGuard {
     }
 }
 
-
 impl PartialEq for FdGuard {
     fn eq(&self, other: &FdGuard) -> bool {
         self.fd == other.fd
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-struct EventedFdGuard(Arc<FdGuard>);
-
-impl Evented for EventedFdGuard {
-    #[inline]
-    fn register(&self,
-                poll: &mio::Poll,
-                token: mio::Token,
-                interest: mio::Ready,
-                opts: mio::PollOpt)
-                -> io::Result<()>
-    {
-        EventedFd(&(self.fd)).register(poll, token, interest, opts)
-    }
-
-    #[inline]
-    fn reregister(&self,
-                  poll: &mio::Poll,
-                  token: mio::Token,
-                  interest: mio::Ready,
-                  opts: mio::PollOpt)
-                  -> io::Result<()>
-    {
-        EventedFd(&(self.fd)).reregister(poll, token, interest, opts)
-    }
-
-    #[inline]
-    fn deregister(&self, poll: &mio::Poll) -> io::Result<()> {
-        EventedFd(&self.fd).deregister(poll)
-    }
-}
-
-impl io::Read for EventedFdGuard {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match read_into_buffer(self.fd, buf) {
-            i if i >= 0 => Ok(i as usize),
-            _ => Err(io::Error::last_os_error()),
-        }
-    }
-}
-
-impl Deref for EventedFdGuard {
-    type Target = Arc<FdGuard>;
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-
-}
-
-// Use this when 1.24 is available for use. We can use the hard-coded 16 due to Linux's ABI
-// guarantees.
-// const EVENT_MAX_SIZE: usize = mem::size_of::<ffi::inotify_event>() + (FILENAME_MAX as usize) + 1;
-const EVENT_MAX_SIZE: usize = 16 + (FILENAME_MAX as usize) + 1;
-
-/// Stream of inotify events
-///
-/// Allows for streaming events returned by [`Inotify::event_stream`].
-///
-/// [`Inotify::event_stream`]: struct.Inotify.html#method.event_stream
-pub struct EventStream {
-    fd: PollEvented<EventedFdGuard>,
-    buffer: [u8; EVENT_MAX_SIZE],
-    pos: usize,
-    size: usize,
-}
-
-impl EventStream {
-    /// Returns a new `EventStream` associated with the default reactor.
-    fn new(fd: Arc<FdGuard>) -> Self {
-        EventStream {
-            fd: PollEvented::new(EventedFdGuard(fd)),
-            buffer: [0; EVENT_MAX_SIZE],
-            pos: 0,
-            size: 0,
-        }
-    }
-
-    /// Returns a new `EventStream` associated with the specified reactor.
-    fn new_with_handle(fd: Arc<FdGuard>, handle: &Handle) -> io::Result<Self> {
-        Ok(EventStream {
-            fd: PollEvented::new_with_handle(EventedFdGuard(fd), handle)?,
-            buffer: [0; EVENT_MAX_SIZE],
-            pos: 0,
-            size: 0,
-        })
-    }
-}
-
-impl Stream for EventStream {
-    type Item = EventOwned;
-    type Error = io::Error;
-
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error>
-    {
-        if 0 < self.size {
-            let (step, event) = Event::from_buffer(
-                Arc::downgrade(self.fd.get_ref()),
-                &self.buffer[self.pos..],
-                self.size,
-            );
-            self.pos += step;
-            self.size -= step;
-
-            return Ok(Async::Ready(Some(event.into_owned())));
-        }
-
-        let num_bytes = try_ready!(self.fd.poll_read(&mut self.buffer)) as usize;
-
-        if num_bytes == 0 {
-            return Ok(Async::Ready(None));
-        }
-
-        let (step, event) = Event::from_buffer(
-            Arc::downgrade(self.fd.get_ref()),
-            &self.buffer,
-            num_bytes,
-        );
-        self.pos = step;
-        self.size = num_bytes - step;
-
-        Ok(Async::Ready(Some(event.into_owned())))
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,145 @@
+extern crate mio;
+extern crate tokio_io;
+
+use futures::{Async, Poll, Stream};
+
+use super::*;
+use self::{
+    mio::{
+        event::Evented,
+        unix::EventedFd,
+    },
+    tokio_io::AsyncRead,
+};
+
+use tokio_reactor::{Handle, PollEvented};
+
+use std::{
+    io,
+    sync::Arc,
+};
+
+/// Stream of inotify events
+///
+/// Allows for streaming events returned by [`Inotify::event_stream`].
+///
+/// [`Inotify::event_stream`]: struct.Inotify.html#method.event_stream
+pub struct EventStream {
+    fd: PollEvented<EventedFdGuard>,
+    buffer: [u8; EVENT_MAX_SIZE],
+    pos: usize,
+    size: usize,
+}
+
+// Use this when 1.24 is available for use. We can use the hard-coded 16 due to Linux's ABI
+// guarantees.
+// const EVENT_MAX_SIZE: usize = mem::size_of::<ffi::inotify_event>() + (FILENAME_MAX as usize) + 1;
+const EVENT_MAX_SIZE: usize = 16 + (FILENAME_MAX as usize) + 1;
+
+impl EventStream {
+    /// Returns a new `EventStream` associated with the default reactor.
+    pub(crate) fn new(fd: Arc<FdGuard>) -> Self {
+        EventStream {
+            fd: PollEvented::new(EventedFdGuard(fd)),
+            buffer: [0; EVENT_MAX_SIZE],
+            pos: 0,
+            size: 0,
+        }
+    }
+
+    /// Returns a new `EventStream` associated with the specified reactor.
+     pub(crate) fn new_with_handle(fd: Arc<FdGuard>, handle: &Handle) -> io::Result<Self> {
+        Ok(EventStream {
+            fd: PollEvented::new_with_handle(EventedFdGuard(fd), handle)?,
+            buffer: [0; EVENT_MAX_SIZE],
+            pos: 0,
+            size: 0,
+        })
+    }
+}
+
+impl Stream for EventStream {
+    type Item = EventOwned;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error>
+    {
+        if 0 < self.size {
+            let (step, event) = Event::from_buffer(
+                Arc::downgrade(self.fd.get_ref()),
+                &self.buffer[self.pos..],
+                self.size,
+            );
+            self.pos += step;
+            self.size -= step;
+
+            return Ok(Async::Ready(Some(event.into_owned())));
+        }
+
+        let num_bytes = try_ready!(self.fd.poll_read(&mut self.buffer)) as usize;
+
+        if num_bytes == 0 {
+            return Ok(Async::Ready(None));
+        }
+
+        let (step, event) = Event::from_buffer(
+            Arc::downgrade(self.fd.get_ref()),
+            &self.buffer,
+            num_bytes,
+        );
+        self.pos = step;
+        self.size = num_bytes - step;
+
+        Ok(Async::Ready(Some(event.into_owned())))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct EventedFdGuard(Arc<FdGuard>);
+
+impl Evented for EventedFdGuard {
+    #[inline]
+    fn register(&self,
+                poll: &mio::Poll,
+                token: mio::Token,
+                interest: mio::Ready,
+                opts: mio::PollOpt)
+                -> io::Result<()>
+    {
+        EventedFd(&(self.fd)).register(poll, token, interest, opts)
+    }
+
+    #[inline]
+    fn reregister(&self,
+                  poll: &mio::Poll,
+                  token: mio::Token,
+                  interest: mio::Ready,
+                  opts: mio::PollOpt)
+                  -> io::Result<()>
+    {
+        EventedFd(&(self.fd)).reregister(poll, token, interest, opts)
+    }
+
+    #[inline]
+    fn deregister(&self, poll: &mio::Poll) -> io::Result<()> {
+        EventedFd(&self.fd).deregister(poll)
+    }
+}
+
+impl io::Read for EventedFdGuard {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match read_into_buffer(self.fd, buf) {
+            i if i >= 0 => Ok(i as usize),
+            _ => Err(io::Error::last_os_error()),
+        }
+    }
+}
+
+impl Deref for EventedFdGuard {
+    type Target = Arc<FdGuard>;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+
+}


### PR DESCRIPTION
This branch changes the implementation of `Stream` for `EventStream`
to use `mio` and `tokio_reactor` to register interest in events on
the Inotify file descriptor with the reactor, rather than using
`task::current().notify()` to unpark the task in the executor when
polling the fd would block.

Since the reactor is intended to drive all IO resources (such as the
inotify FD) and to be the bridge between tasks in the executor and
events from the OS, using `PollEvented` is a more correct way to
implement the stream.

This branch shouldn't result in any noticeable changes in behaviour,
but will hopefully allow tokio to manage Inotify's IO events more
intelligently.