### PR TITLE
chore: Update dependency on inotify-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ stream = ["futures", "mio", "tokio-io", "tokio-reactor"]
 [dependencies]
 bitflags      = "1"
 futures       = { version = "0.1", optional = true }
-inotify-sys   = "0.1.1"
+inotify-sys   = "0.1.3"
 libc          = "0.2"
 mio           = { version = "0.6", optional = true }
 tokio-io      = { version = "0.1", optional = true }


### PR DESCRIPTION
It contains an important bug fix:
https://github.com/inotify-rs/inotify-sys/pull/9