### PR TITLE
examples: add an example using tokio's event-loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci   = { repository = "inotify-rs/inotify" }
 
 [features]
 default = ["stream"]
-stream = ["futures", "mio", "tokio-io", "tokio-reactor"]
+stream = ["futures", "mio", "tokio", "tokio-io", "tokio-reactor"]
 
 
 [dependencies]
@@ -35,12 +35,12 @@ futures       = { version = "0.1", optional = true }
 inotify-sys   = "0.1.3"
 libc          = "0.2"
 mio           = { version = "0.6", optional = true }
+tokio         = { version = "0.1", optional = true }
 tokio-io      = { version = "0.1", optional = true }
 tokio-reactor = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
-
 
 [[example]]
 name              = "stream"
@@ -49,6 +49,9 @@ required-features = ["stream"]
 [[example]]
 name = "watch"
 
+[[example]]
+name = "issue-120-workaround"
+required-features = ["stream"]
 
 [package.metadata.release]
 pre-release-commit-message = "chore: Release version {{version}}"

--- a/examples/issue-120-workaround.rs
+++ b/examples/issue-120-workaround.rs
@@ -1,0 +1,38 @@
+extern crate futures;
+extern crate inotify;
+extern crate tempdir;
+extern crate tokio;
+
+use inotify::{Inotify, WatchMask};
+use std::{fs::File, io, thread, time::Duration};
+use tempdir::TempDir;
+use tokio::prelude::*;
+
+fn main() -> Result<(), io::Error> {
+    /// XXX: this is a workaround to set the inotify's buffer to be
+    /// used, matching with tokio's runtime API
+    /// https://github.com/inotify-rs/inotify/issues/120
+    static mut BUFFER: [u8; 32] = [0; 32];
+
+    let mut inotify = Inotify::init()?;
+
+    let dir = TempDir::new("inotify-rs-test")?;
+
+    inotify.add_watch(dir.path(), WatchMask::CREATE | WatchMask::MODIFY)?;
+
+    thread::spawn::<_, Result<(), io::Error>>(move || loop {
+        File::create(dir.path().join("file"))?;
+        thread::sleep(Duration::from_millis(500));
+    });
+
+    let future = inotify
+        .event_stream(unsafe { &mut BUFFER })
+        .map_err(|e| println!("inotify error: {:?}", e))
+        .for_each(move |event| {
+            println!("event: {:?}", event);
+            Ok(())
+        });
+
+    tokio::run(future);
+    Ok(())
+}


### PR DESCRIPTION
This example shows how to use inotify's stream as future polled by tokio's event loop which is cheap in computational terms using Rust idioms.