### PR TITLE
Ensure file descriptor is closed on drop

### DIFF
--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -107,7 +107,7 @@ impl Inotify {
                 Ok(Inotify {
                     fd: Arc::new(FdGuard {
                         fd,
-                        close_on_drop: AtomicBool::new(false),
+                        close_on_drop: AtomicBool::new(true),
                     }),
                 }),
         }


### PR DESCRIPTION
This fixes the incorrect initialization of close_on_drop, which
caused the file descriptor to never be released because close_on_drop
is never true.